### PR TITLE
Implement gradle download task for food.csv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ bin/
 
 ### Mac OS ###
 .DS_Store
+
+### Project large assets ###
+assets/food.csv

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,7 @@ tasks.register("prepareAssets") {
     }
 }
 
-tasks.named("build") {
+tasks.named("compileKotlin") {
     dependsOn(downloadFoodCSV)
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,8 @@
+import de.undercouch.gradle.tasks.download.Download
+
 plugins {
     kotlin("jvm") version "2.1.10"
+    id("de.undercouch.download") version "5.6.0"
 }
 
 group = "org.damascus"
@@ -16,6 +19,23 @@ dependencies {
 tasks.test {
     useJUnitPlatform()
 }
+
+val downloadFoodCSV by tasks.registering(Download::class) {
+    src("https://drive.usercontent.google.com/download?id=1px860X8gO_AFHNkcNFe64e_il_bDaKSI&export=download&authuser=0&confirm=t&uuid=51b6e15b-0cbc-4e92-932a-f226c6ddec08&at=APcmpozkRgttvXbbZitl5BiFIdg_%3A1744613357267")
+    dest(file("$rootDir/assets/food.csv"))
+    overwrite(false)
+}
+
+tasks.register("prepareAssets") {
+    doLast {
+        file("$rootDir/assets").mkdirs()
+    }
+}
+
+tasks.named("build") {
+    dependsOn(downloadFoodCSV)
+}
+
 kotlin {
     jvmToolchain(17)
 }


### PR DESCRIPTION
This implementation prevents Git from tracking the large food.csv file.

Whenever the compileKotlin task is triggered, the file will be automatically downloaded if it doesn't already exist on the local machine. This ensures consistency across different collaborators and environments.

Big thanks to @Al-Taie  for suggesting this approach, and to @HarithBashar  for assisting with testing.

