### PR TITLE
Hotfix: rename class usages of IdentifyIraqiMealsUseCase

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,5 +48,5 @@ tasks.named("compileKotlin") {
 }
 
 kotlin {
-    jvmToolchain(23)
+    jvmToolchain(17)
 }

--- a/src/main/kotlin/di/AppModule.kt
+++ b/src/main/kotlin/di/AppModule.kt
@@ -24,7 +24,7 @@ val appModule = module {
     single { GetFirstTenMealsUseCase(get()) }
     single { GetEasyFoodSuggestionsUseCase(get()) }
     single { GetKetoMealUseCase(get()) }
-    single { IdentifyIraqiMealsUseCase(get()) }
+    single { IdentifyMealsByNationalityUseCase(get()) }
     single { SearchMealByNameUseCase(get()) }
     single { GetMealsByDateUseCase(get()) }
 

--- a/src/main/kotlin/di/UseCasesModule.kt
+++ b/src/main/kotlin/di/UseCasesModule.kt
@@ -17,7 +17,7 @@ val useCaseModule = module {
     single { GetMealsByDateUseCase(get())}
     single { GetRandomMealUseCase(get() ) }
     single { GetRandomPotatoMealsUseCase(get()) }
-    single { IdentifyIraqiMealsUseCase(get()) }
+    single { IdentifyMealsByNationalityUseCase(get()) }
     single { SearchMealByNameUseCase(get()) }
     single { SortSeafoodMealsByContentUseCase(get()) }
     single { FindMealsByCaloriesAndProtein(get()) }

--- a/src/main/kotlin/presentation/FoodChangeModeUi.kt
+++ b/src/main/kotlin/presentation/FoodChangeModeUi.kt
@@ -16,7 +16,7 @@ class FoodChangeMoodUi(
     private val getHighCalorieMealUseCase: GetHighCalorieMealUseCase,
     private val getEggFreeSweetUseCase: GetEggFreeSweetUseCase,
     private val getKetoMealUseCase: GetKetoMealUseCase,
-    private val identifyIraqiMealsUseCase: IdentifyIraqiMealsUseCase,
+    private val identifyIraqiMealsUseCase: IdentifyMealsByNationalityUseCase,
     private val searchMealByNameUseCase: SearchMealByNameUseCase,
     private val getRandomMealUseCase: GetRandomMealUseCase,
     private val getMealsByDateUseCase: GetMealsByDateUseCase,


### PR DESCRIPTION
Class name was changed, however usages weren't, this was causing an error whenever running the application.

Another minor change was introduced in the gradle file, jvmToolchain was changed to 23, this PR rolls it back to 17 as it was.